### PR TITLE
Update nlme import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ dkms.conf
 # Backup files
 *~
 *.bak
+*.Rproj

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ matrix:
     os: osx
 sudo: false
 cache: packages
+r_packages:
+  - nlme
 r_github_packages:
 - statnet/statnet.common
 - statnet/network

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Depends:
 Imports:
     robustbase (>= 0.93.5),
     coda (>= 0.19.2),
-    nlme (>= 3.1.140),
+    nlme (>= 3.1-140),
     MASS (>= 7.3.51.4),
     statnet.common (>= 4.2.0)
 LinkingTo:


### PR DESCRIPTION
The import of nlme was for 3.1.140 but the format of the version of the package is 3.1-140. I think this was causing this build error on Travis:

https://travis-ci.org/statnet/tergm/jobs/532741813