### PR TITLE
print progress to stderr

### DIFF
--- a/R/ergm.godfather.R
+++ b/R/ergm.godfather.R
@@ -266,7 +266,7 @@ tergm.godfather <- function(formula, changes=NULL, toggles=changes[,-4,drop=FALS
     maxedges <- Clist$nedges + maxedges.sd*control$GF.init.maxedges.mul
   }
 
-  if(verbose) cat("Applying changes...\n")
+  if(verbose) message("Applying changes...")
   repeat{
     z <- .C("godfather_wrapper",
             as.integer(Clist$tails), as.integer(Clist$heads),
@@ -304,7 +304,7 @@ tergm.godfather <- function(formula, changes=NULL, toggles=changes[,-4,drop=FALS
   stats <- mcmc(stats, start=if(stats.start) start else start+1)
   
   if(end.network){ 
-    if(verbose) cat("Creating new network...\n")
+    if(verbose) message("Creating new network...")
     newnetwork <- as.network(pending_update_network(nw,z))
     newnetwork %n% "time" <- z$time
     newnetwork %n% "lasttoggle" <- z$lasttoggle

--- a/R/simulate.stergm.R
+++ b/R/simulate.stergm.R
@@ -630,7 +630,7 @@ simulate.networkDynamic <- function(object, nsim=1, seed=NULL,
     object%n%'vertex.pid'<-'tergm_pid'
   }
   
-  if(verbose) cat("extracting state of networkDynamic at time ",start,"\n")
+  if(verbose) message("extracting state of networkDynamic at time  ",start)
   
   # extract nwd to nw
   
@@ -665,7 +665,7 @@ simulate.networkDynamic <- function(object, nsim=1, seed=NULL,
   ## If all the user wants is statistics or a list of toggles, we are done.
   if(output!="networkDynamic") return(sim)
 
-  if(verbose) cat("Updating networkDynamic ")
+  if(verbose) message("Updating networkDynamic ", appendLF = FALSE)
   
   object  <- networkDynamic.apply.changes(object, sim)
   # set up net.obs.period list to describe time period simulated
@@ -673,7 +673,7 @@ simulate.networkDynamic <- function(object, nsim=1, seed=NULL,
   
   if(verbose){
     obs<-(object%n%'net.obs.period')$observations
-    cat("with simulated time: (",obs[[length(obs)]],").\n")
+    message("with simulated time: ( ",obs[[length(obs)]]," ).")
   }
   
   attributes(object) <- c(attributes(object), # Don't clobber existing attributes!

--- a/R/stergm.CMLE.R
+++ b/R/stergm.CMLE.R
@@ -118,7 +118,7 @@ stergm.CMLE <- function(nw, formation, dissolution, constraints, times, offset.c
   if(!is.null(control$CMLE.control.form$init)){
     # Check length of control$CMLE.control.form$init.
     if(length(control$CMLE.control.form$init)!=length(model.form$etamap$offsettheta)) {
-      if(verbose) cat("control$CMLE.control.form$init is", control$CMLE.control.form$init, "\n", "number of statistics is",length(model.form$coef.names), "\n")
+      if(verbose) message("control$CMLE.control.form$init is ", paste(control$CMLE.control.form$init, collapse = " "), "\n", " number of statistics is ", length(model.form$coef.names))
       stop(paste("Invalid starting formation parameter vector control$CMLE.control.form$init:",
                  "wrong number of parameters."))
     }
@@ -129,7 +129,7 @@ stergm.CMLE <- function(nw, formation, dissolution, constraints, times, offset.c
   if(!is.null(control$CMLE.control.diss$init)){
     # Check length of control$CMLE.control.diss$init.
     if(length(control$CMLE.control.diss$init)!=length(model.diss$etamap$offsettheta)) {
-      if(verbose) cat("control$CMLE.control.diss$init is", control$CMLE.control.diss$init, "\n", "number of statistics is",length(model.diss$coef.names), "\n")
+      if(verbose) message("control$CMLE.control.diss$init is ", paste(control$CMLE.control.diss$init, collapse = " "), "\n", " number of statistics is ", length(model.diss$coef.names))
       stop(paste("Invalid starting dissolution parameter vector control$CMLE.control.diss$init:",
                  "wrong number of parameters."))
     }
@@ -144,9 +144,9 @@ stergm.CMLE <- function(nw, formation, dissolution, constraints, times, offset.c
                      CMPLE = "MPLE")
   
   # Now, call the ergm()s:
-  cat("Fitting formation...\n")
+  message("Fitting formation...")
   fit.form <- ergm(formation, constraints=constraints.form, offset.coef=offset.coef.form, eval.loglik=eval.loglik, estimate=ergm.estimate, control=control$CMLE.control.form, verbose=verbose)
-  cat("Fitting dissolution...\n")
+  message("Fitting dissolution...")
   fit.diss <- ergm(dissolution, constraints=constraints.diss, offset.coef=offset.coef.diss, eval.loglik=eval.loglik, estimate=ergm.estimate, control=control$CMLE.control.diss, verbose=verbose)
 
   # Construct the output list. Conveniently, this is mainly a list consisting of two ergms.

--- a/R/stergm.EGMME.GD.R
+++ b/R/stergm.EGMME.GD.R
@@ -44,7 +44,7 @@ stergm.EGMME.GD <- function(theta.form0, theta.diss0, nw, model.form, model.diss
     h.fits <-
       if(!is.null(ergm.getCluster(control))){
         requireNamespace('parallel')
-        if(verbose) {cat("Calling lm/lmrob:\n"); print(gc())}
+        if(verbose) {message("Calling lm/lmrob:"); message_print(gc())}
         out <- parallel::clusterApplyLB(ergm.getCluster(control), 1:q,
                        function(i){
                          y<-ys[,i]
@@ -56,7 +56,7 @@ stergm.EGMME.GD <- function(theta.form0, theta.diss0, nw, model.form, model.diss
                                               silent=TRUE))
                          
                        })
-        if(verbose) print(gc())
+        if(verbose) message_print(gc())
         out
       }else{
         lapply(1:q,
@@ -132,18 +132,18 @@ stergm.EGMME.GD <- function(theta.form0, theta.diss0, nw, model.form, model.diss
     
     
     if(verbose>1){
-      cat("New interval:",control$SA.interval ,"\n")
+      message("New interval: ", control$SA.interval)
     }
     
     ## Detect parameters whose effect we aren't able to reliably detect.
     ineffectual.pars <- !apply(G.signif,2,any)
 
     if(all(ineffectual.pars)){
-      if(test.G || verbose>0) cat("None of the parameters have a detectable effect. Increasing jitter.\n" )
+      if(test.G || verbose>0) message("None of the parameters have a detectable effect. Increasing jitter.")
       control$jitter[!offsets] <- control$jitter[!offsets]*2
     }
     else if(any(ineffectual.pars)){
-      if(test.G) cat("Parameters",paste.and(p.names[!offsets][ineffectual.pars]),"do not have a detectable effect. Shifting jitter to them.\n" )
+      if(test.G) message("Parameters ", paste.and(p.names[!offsets][ineffectual.pars]), " do not have a detectable effect. Shifting jitter to them." )
       control$jitter[!offsets] <- control$jitter[!offsets] * (ineffectual.pars+1/2) / mean(control$jitter[!offsets] * (ineffectual.pars+1/2))
     }
 
@@ -166,27 +166,27 @@ stergm.EGMME.GD <- function(theta.form0, theta.diss0, nw, model.form, model.diss
     names(par.eff)<-colnames(G.pvals)<-colnames(G)<-p.names[!offsets]
     rownames(G.pvals)<-rownames(G)<-q.names
     if(verbose>1){
-      cat("Most recent parameters:\n")
-      cat("Formation:\n")
-      for(state in states) print(state$eta.form)
-      cat("Dissolution:\n")
-      for(state in states) print(state$eta.diss)
-      cat("Target differences (most recent):\n")
-      for(state in states) print(state$nw.diff)
-      cat("Target differences (last run):\n")
-      print(colMeans(oh.last[,-(1:p),drop=FALSE]))
-      cat("Approximate objective function (most recent):\n")
-      print(mahalanobis(oh[nrow(oh),-(1:p),drop=FALSE],0,cov=w,inverted=TRUE))
-      cat("Approximate objective function (last run):\n")
-      print(mahalanobis(colMeans(oh.last[,-(1:p),drop=FALSE]),0,cov=w,inverted=TRUE))
-      cat("Estimaged gradient p-values:\n")
-      print(G.pvals)
-      cat("Estimated gradient:\n")
-      print(G)
-      cat("Normalized parameter effects:\n")
-      print(par.eff)
-      cat("Estimated covariance of statistics:\n")
-      print(v)
+      message("Most recent parameters:")
+      message("Formation:")
+      for(state in states) message_print(state$eta.form)
+      message("Dissolution:")
+      for(state in states) message_print(state$eta.diss)
+      message("Target differences (most recent):")
+      for(state in states) message_print(state$nw.diff)
+      message("Target differences (last run):")
+      message_print(colMeans(oh.last[,-(1:p),drop=FALSE]))
+      message("Approximate objective function (most recent):")
+      message_print(mahalanobis(oh[nrow(oh),-(1:p),drop=FALSE],0,cov=w,inverted=TRUE))
+      message("Approximate objective function (last run):")
+      message_print(mahalanobis(colMeans(oh.last[,-(1:p),drop=FALSE]),0,cov=w,inverted=TRUE))
+      message("Estimaged gradient p-values:")
+      message_print(G.pvals)
+      message("Estimated gradient:")
+      message_print(G)
+      message("Normalized parameter effects:")
+      message_print(par.eff)
+      message("Estimated covariance of statistics:")
+      message_print(v)
     }
 
     # Plot if requested.
@@ -219,10 +219,10 @@ stergm.EGMME.GD <- function(theta.form0, theta.diss0, nw, model.form, model.diss
     colnames(control$GainM) <- q.names
     
     if(verbose>1){
-      cat("New deviation -> coefficient map:\n")
-      print(control$GainM)
-      cat("New jitter cancelation matrix:\n")
-      print(control$dejitter)
+      message("New deviation -> coefficient map:")
+      message_print(control$GainM)
+      message("New jitter cancelation matrix:")
+      message_print(control$dejitter)
     }
 
     if(update.jitter){
@@ -231,20 +231,20 @@ stergm.EGMME.GD <- function(theta.form0, theta.diss0, nw, model.form, model.diss
     }
     
     if(verbose>1){
-      cat("New jitter values:\n")
-      print(control$jitter)
+      message("New jitter values:")
+      message_print(control$jitter)
     }
 
     control$dev.guard <- apply(oh[,-(1:p),drop=FALSE],2,function(x) quantile(abs(x),.9)) * control$SA.guard.mul
     if(verbose>1){
-      cat("New deviation guard values:\n")
-      print(control$dev.guard)
+      message("New deviation guard values:")
+      message_print(control$dev.guard)
     }
 
     control$par.guard <- apply(abs(diff(oh[,1:p,drop=FALSE],lag=control$SA.runlength*control$SA.interval-1)),2,median) * control$SA.guard.mul
     if(verbose>1){
-      cat("New parameter guard values:\n")
-      print(control$par.guard)
+      message("New parameter guard values:")
+      message_print(control$par.guard)
     }
     
     list(control=control,

--- a/R/stergm.EGMME.R
+++ b/R/stergm.EGMME.R
@@ -140,7 +140,7 @@ stergm.EGMME <- function(nw, formation, dissolution, constraints, offset.coef.fo
     if(length(nw.stats)!=length(target.stats))
       stop("Incorrect length of the target.stats vector: should be ", length(nw.stats), " but is ",length(target.stats),".")
         
-    if(verbose) cat("Constructing an approximate response network.\n")
+    if(verbose) message("Constructing an approximate response network.")
     ## If target.stats are given, overwrite the given network and targets
     ## with SAN-ed network and targets.
     
@@ -157,19 +157,19 @@ stergm.EGMME <- function(nw, formation, dissolution, constraints, offset.coef.fo
     nw.stats <- summary(model.mon, nw)
 
     if(verbose){
-      cat("SAN summary statistics:\n")
-      print(nw.stats)
-      cat("Meanstats Goal:\n")
-      print(target.stats)
-      cat("Difference: SAN target.stats - Goal target.stats =\n")
-      print(round(nw.stats-target.stats,0))
+      message("SAN summary statistics:")
+      message_print(nw.stats)
+      message("Meanstats Goal:")
+      message_print(target.stats)
+      message("Difference: SAN target.stats - Goal target.stats =")
+      message_print(round(nw.stats-target.stats,0))
     }
   }
 
   model.mon$nw.stats <- nw.stats
   model.mon$target.stats <- if(!is.null(target.stats)) vector.namesmatch(target.stats, names(model.mon$nw.stats)) else model.mon$nw.stats
 
-  if (verbose) cat("Initializing Metropolis-Hastings proposals.\n")
+  if (verbose) message("Initializing Metropolis-Hastings proposals.")
   proposal.form <- ergm_proposal(constraints, weights=control$MCMC.prop.weights.form, control$MCMC.prop.args.form, nw, class="f")
   proposal.diss <- ergm_proposal(constraints, weights=control$MCMC.prop.weights.diss, control$MCMC.prop.args.diss, nw, class="d")
 
@@ -182,7 +182,7 @@ stergm.EGMME <- function(nw, formation, dissolution, constraints, offset.coef.fo
   if(!is.null(control$init.form)){
     # Check length of control$init.form.
     if(length(control$init.form)!=length(model.form$etamap$offsettheta)) {
-      if(verbose) cat("control$init.form is", control$init.form, "\n", "number of statistics is",length(model.form$coef.names), "\n")
+      if(verbose) message("control$init.form is ", paste(control$init.form, collapse = " "), "\n", " number of statistics is ", length(model.form$coef.names))
       stop(paste("Invalid starting formation parameter vector control$init.form:",
                  "wrong number of parameters."))
     }
@@ -193,7 +193,7 @@ stergm.EGMME <- function(nw, formation, dissolution, constraints, offset.coef.fo
   if(!is.null(control$init.diss)){
     # Check length of control$init.diss.
     if(length(control$init.diss)!=length(model.diss$etamap$offsettheta)) {
-      if(verbose) cat("control$init.diss is", control$init.diss, "\n", "number of statistics is",length(model.diss$coef.names), "\n")
+      if(verbose) message("control$init.diss is ", paste(control$init.diss, collapse = " "), "\n", " number of statistics is ", length(model.diss$coef.names))
       stop(paste("Invalid starting dissolution parameter vector control$init.diss:",
                  "wrong number of parameters."))
     }
@@ -203,11 +203,11 @@ stergm.EGMME <- function(nw, formation, dissolution, constraints, offset.coef.fo
 
   initialfit <- stergm.EGMME.initialfit(formation, dissolution, targets, control$init.form, control$init.diss, nw, model.form, model.diss, model.mon, control, verbose)
   
-  if(verbose) cat("Fitting STERGM Equilibrium GMME.\n")
+  if(verbose) message("Fitting STERGM Equilibrium GMME.")
 
   if(control$parallel){
     ergm.getCluster(control, verbose=verbose)
-    if(verbose && !is.null(ergm.getCluster(control))) cat("Using parallel cluster.\n")
+    if(verbose && !is.null(ergm.getCluster(control))) message("Using parallel cluster.")
   }
   
   Cout <- switch(control$EGMME.main.method,

--- a/R/stergm.EGMME.initialfit.R
+++ b/R/stergm.EGMME.initialfit.R
@@ -27,7 +27,7 @@ stergm.EGMME.initialfit<-function(formation, dissolution, targets, init.form, in
                 )
            && all(.do(model.diss$coef.names) %in% model.form$coef.names)
            && is.dyad.independent(model.diss)){
-    if(verbose) cat("Formation statistics are analogous to targeted statistics, dissolution is fixed or is edges with a mean.age target, dissolution terms appear to have formation analogs, and dissolution process is dyad-independent, so using edges dissolution approximation  (Carnegie et al.).\n")
+    if(verbose) message("Formation statistics are analogous to targeted statistics, dissolution is fixed or is edges with a mean.age target, dissolution terms appear to have formation analogs, and dissolution process is dyad-independent, so using edges dissolution approximation  (Carnegie et al.).")
 
     if(!all(model.diss$etamap$offsettheta)){ # This must mean that the two provisos above are satisfied.
       mean.age <- model.mon$target.stats[.do(model.mon$coef.names)=="mean.age"]


### PR DESCRIPTION
References statnet/tergm#2.

Converted progress-related printing to `message` or `message_print`.  Some of this includes e.g. coefficient values but I considered these to be printed as a form of progress report (not a `summary`-style coefficient table).

Three instances of `print` called on progress-related plots were left as `print`; it appears these generally do not produce any text output (just display the plot).  `message_print` also worked here (in that it displayed the plots), but `print` seemed more natural for just telling the plots to display themselves.

Whitespace in printed output was generally preserved (even if it looked to me like there was an extra space or something).

`CMLE` and `sim_gf_sum` tests appear to be failing in `master` (unrelated to this PR).