### PR TITLE
update NULL lasttoggle handling

### DIFF
--- a/R/ergm.godfather.R
+++ b/R/ergm.godfather.R
@@ -271,6 +271,7 @@ tergm.godfather <- function(formula, changes=NULL, toggles=changes[,-4,drop=FALS
     z <- .C("godfather_wrapper",
             as.integer(Clist$tails), as.integer(Clist$heads),
             time = if(is.null(Clist$time)) as.integer(0) else as.integer(Clist$time),
+            lasttoggle_flag = as.integer(!is.null(Clist$lasttoggle)),
             lasttoggle = as.integer(NVL(Clist$lasttoggle,0)),             
             as.integer(Clist$nedges),
             as.integer(Clist$n),

--- a/R/ergm.godfather.R
+++ b/R/ergm.godfather.R
@@ -266,13 +266,15 @@ tergm.godfather <- function(formula, changes=NULL, toggles=changes[,-4,drop=FALS
     maxedges <- Clist$nedges + maxedges.sd*control$GF.init.maxedges.mul
   }
 
+  lasttoggle_flag <- as.integer(!is.null(Clist$lasttoggle))
+
   if(verbose) message("Applying changes...")
   repeat{
     z <- .C("godfather_wrapper",
             as.integer(Clist$tails), as.integer(Clist$heads),
             time = if(is.null(Clist$time)) as.integer(0) else as.integer(Clist$time),
-            lasttoggle_flag = as.integer(!is.null(Clist$lasttoggle)),
-            lasttoggle = as.integer(NVL(Clist$lasttoggle,0)),             
+            lasttoggle_flag,
+            lasttoggle = as.integer(Clist$lasttoggle),             
             as.integer(Clist$nedges),
             as.integer(Clist$n),
             as.integer(Clist$dir), as.integer(Clist$bipartite),
@@ -308,7 +310,7 @@ tergm.godfather <- function(formula, changes=NULL, toggles=changes[,-4,drop=FALS
     if(verbose) message("Creating new network...")
     newnetwork <- as.network(pending_update_network(nw,z))
     newnetwork %n% "time" <- z$time
-    newnetwork %n% "lasttoggle" <- z$lasttoggle
+    newnetwork %n% "lasttoggle" <- if(lasttoggle_flag) z$lasttoggle else NULL
 
     attr(newnetwork,"stats")<-stats
     newnetwork

--- a/R/stergm.EGMME.SA.R
+++ b/R/stergm.EGMME.SA.R
@@ -584,6 +584,7 @@ stergm.EGMME.SA.Phase2.C <- function(state, model.form, model.diss, model.mon,
             # Observed/starting network. 
             as.integer(Clist.form$tails), as.integer(Clist.form$heads),
             time = as.integer(min(Clist.form$time,Clist.diss$time,Clist.diss$time)),
+            lasttoggle_flag = as.integer(!is.null(NVL(Clist.form$lasttoggle,Clist.diss$lasttoggle,Clist.mon$lasttoggle))),
             lasttoggle = as.integer(NVL(Clist.form$lasttoggle,Clist.diss$lasttoggle,Clist.mon$lasttoggle,0)),  
             as.integer(Clist.form$nedges),
             as.integer(Clist.form$n),

--- a/R/stergm.EGMME.SA.R
+++ b/R/stergm.EGMME.SA.R
@@ -579,13 +579,15 @@ stergm.EGMME.SA.Phase2.C <- function(state, model.form, model.diss, model.mon,
   eta.form <- deInf(state$eta.form)
   eta.diss <- deInf(state$eta.diss)
   
+  lasttoggle_flag <- as.integer(!is.null(NVL(Clist.form$lasttoggle,Clist.diss$lasttoggle,Clist.mon$lasttoggle)))
+  
   repeat{
     z <- .C("MCMCDynSArun_wrapper",
             # Observed/starting network. 
             as.integer(Clist.form$tails), as.integer(Clist.form$heads),
             time = as.integer(min(Clist.form$time,Clist.diss$time,Clist.diss$time)),
-            lasttoggle_flag = as.integer(!is.null(NVL(Clist.form$lasttoggle,Clist.diss$lasttoggle,Clist.mon$lasttoggle))),
-            lasttoggle = as.integer(NVL(Clist.form$lasttoggle,Clist.diss$lasttoggle,Clist.mon$lasttoggle,0)),  
+            lasttoggle_flag,
+            lasttoggle = as.integer(NVL(Clist.form$lasttoggle,Clist.diss$lasttoggle,Clist.mon$lasttoggle)),  
             as.integer(Clist.form$nedges),
             as.integer(Clist.form$n),
             as.integer(Clist.form$dir), as.integer(Clist.form$bipartite),
@@ -643,7 +645,7 @@ stergm.EGMME.SA.Phase2.C <- function(state, model.form, model.diss, model.mon,
 
   newnetwork<-as.network(pending_update_network(state$nw,z))
   newnetwork %n% "time" <- z$time
-  newnetwork %n% "lasttoggle" <- z$lasttoggle
+  newnetwork %n% "lasttoggle" <- if(lasttoggle_flag) z$lasttoggle else NULL
   
   list(nw.diff=z$nw.diff,
        newnetwork=newnetwork,

--- a/R/stergm.getMCMCsample.R
+++ b/R/stergm.getMCMCsample.R
@@ -200,6 +200,7 @@ stergm_MCMC_slave <- function(Clist.form, Clist.diss, Clist.mon, proposal.form, 
             # Observed network.
             as.integer(Clist.form$tails), as.integer(Clist.form$heads),
             time = if(is.null(Clist.form$time)) as.integer(0) else as.integer(Clist.form$time),
+            lasttoggle_flag = as.integer(!is.null(NVL(Clist.form$lasttoggle,Clist.diss$lasttoggle,Clist.mon$lasttoggle))),
             lasttoggle = as.integer(NVL(Clist.form$lasttoggle,Clist.diss$lasttoggle,Clist.mon$lasttoggle,0)),  
             as.integer(Clist.form$nedges),
             as.integer(Clist.form$n),

--- a/R/stergm.getMCMCsample.R
+++ b/R/stergm.getMCMCsample.R
@@ -193,6 +193,9 @@ stergm_MCMC_slave <- function(Clist.form, Clist.diss, Clist.mon, proposal.form, 
   collect.diss<-if(!is.null(control$collect.diss)) control$collect.diss else TRUE
   maxedges <- control$MCMC.init.maxedges
   maxchanges <- control$MCMC.init.maxchanges
+  
+  lasttoggle_flag <- as.integer(!is.null(NVL(Clist.form$lasttoggle,Clist.diss$lasttoggle,Clist.mon$lasttoggle)))
+  
   repeat{
     #FIXME: Separate MCMC control parameters and properly attach them.
     
@@ -200,8 +203,8 @@ stergm_MCMC_slave <- function(Clist.form, Clist.diss, Clist.mon, proposal.form, 
             # Observed network.
             as.integer(Clist.form$tails), as.integer(Clist.form$heads),
             time = if(is.null(Clist.form$time)) as.integer(0) else as.integer(Clist.form$time),
-            lasttoggle_flag = as.integer(!is.null(NVL(Clist.form$lasttoggle,Clist.diss$lasttoggle,Clist.mon$lasttoggle))),
-            lasttoggle = as.integer(NVL(Clist.form$lasttoggle,Clist.diss$lasttoggle,Clist.mon$lasttoggle,0)),  
+            lasttoggle_flag,
+            lasttoggle = as.integer(NVL(Clist.form$lasttoggle,Clist.diss$lasttoggle,Clist.mon$lasttoggle)),  
             as.integer(Clist.form$nedges),
             as.integer(Clist.form$n),
             as.integer(Clist.form$dir), as.integer(Clist.form$bipartite),
@@ -280,9 +283,10 @@ stergm_MCMC_slave <- function(Clist.form, Clist.diss, Clist.mon, proposal.form, 
       NULL
 
   # Blank all elements of z that we don't want to bother returning.
+  # note that we want z$lasttoggle to be NULL if lasttoggle_flag is FALSE
   zn <- names(z)
   for(i in rev(seq_along(zn))){ # Do in reverse, to preserve indexing.
-    if(! zn[i] %in% c("time", "lasttoggle", "newnwtails", "newnwheads", "diffnwtime", "diffnwtails", "diffnwheads", "diffnwdirs", "status"))
+    if(! zn[i] %in% c("time", if(lasttoggle_flag) "lasttoggle", "newnwtails", "newnwheads", "diffnwtime", "diffnwtails", "diffnwheads", "diffnwdirs", "status"))
       z[[i]] <- NULL
   }  
   c(z,

--- a/src/DynSA.c
+++ b/src/DynSA.c
@@ -10,7 +10,7 @@
 #include "DynSA.h"
 
 void MCMCDynSArun_wrapper(// Observed network.
-			     int *tails, int *heads, int *time, int *lasttoggle, int *n_edges,
+			     int *tails, int *heads, int *time, int *lasttoggle_flag, int *lasttoggle, int *n_edges,
 			     int *n_nodes, int *dflag, int *bipartite, 
 			     // Formation terms and proposals.
 			     int *F_nterms, char **F_funnames, char **F_sonames,
@@ -46,7 +46,7 @@ void MCMCDynSArun_wrapper(// Observed network.
   Model *F_m, *D_m, *M_m;
   MHProposal *F_MH, *D_MH;
   
-  if(*lasttoggle == 0) lasttoggle = NULL;
+  if(!*lasttoggle_flag) lasttoggle = NULL;
 
   Vertex *difftime, *difftail, *diffhead;
   difftime = (Vertex *) Calloc(*maxchanges,Vertex);

--- a/src/DynSA.h
+++ b/src/DynSA.h
@@ -14,7 +14,7 @@
 #include "MHproposal.h"
 
 void MCMCDynSArun_wrapper(// Observed network.
-			     int *tails, int *heads, int *time, int *lasttoggle, int *n_edges,
+			     int *tails, int *heads, int *time, int *lasttoggle_flag, int *lasttoggle, int *n_edges,
 			     int *n_nodes, int *dflag, int *bipartite, 
 			     // Formation terms and proposals.
 			     int *F_nterms, char **F_funnames, char **F_sonames,

--- a/src/MCMCDyn.c
+++ b/src/MCMCDyn.c
@@ -112,7 +112,7 @@ void MCMCDyn_finish_common(Network *nwp,
  Wrapper for a call from R.
 *****************/
 void MCMCDyn_wrapper(// Starting network.
-		     int *tails, int *heads, int *time, int *lasttoggle, int *n_edges,
+		     int *tails, int *heads, int *time, int *lasttoggle_flag, int *lasttoggle, int *n_edges,
 		     int *n_nodes, int *dflag, int *bipartite,
 		     // Formation terms and proposals.
 		     int *F_nterms, char **F_funnames, char **F_sonames, 
@@ -146,7 +146,7 @@ void MCMCDyn_wrapper(// Starting network.
   Model *F_m, *D_m, *M_m;
   MHProposal *F_MH, *D_MH;
 
-  if(*lasttoggle == 0) lasttoggle = NULL;
+  if(!*lasttoggle_flag) lasttoggle = NULL;
 
   Vertex *difftime, *difftail, *diffhead;
   int *diffto;

--- a/src/MCMCDyn.h
+++ b/src/MCMCDyn.h
@@ -47,7 +47,7 @@ void MCMCDyn_finish_common(Network *nw,
 			   MHProposal *D_MH);
 
 void MCMCDyn_wrapper(// Starting network.
-		     int *tails, int *heads, int *time, int *lasttoggle, int *n_edges,
+		     int *tails, int *heads, int *time, int *lasttoggle_flag, int *lasttoggle, int *n_edges,
 		     int *n_nodes, int *dflag, int *bipartite,
 		     // Formation terms and proposals.
 		     int *F_nterms, char **F_funnames, char **F_sonames, 

--- a/src/godfather.c
+++ b/src/godfather.c
@@ -20,7 +20,7 @@
  find the changestats that result from starting from an empty network
  and then adding all of the edges to make up an observed network of interest.
 *****************/
-void godfather_wrapper(int *tails, int *heads, int *time, int *lasttoggle, int *n_edges,
+void godfather_wrapper(int *tails, int *heads, int *time, int *lasttoggle_flag, int *lasttoggle, int *n_edges,
 		       int *n_nodes, int *directed_flag, int *bipartite, 
 		       int *nterms, char **funnames, char **sonames, double *inputs,
 		       int *total_toggles, int *toggletimes, 
@@ -35,7 +35,7 @@ void godfather_wrapper(int *tails, int *heads, int *time, int *lasttoggle, int *
   Network *nwp;
   Model *m;
 
-  if(*lasttoggle == 0) lasttoggle = NULL;
+  if(!*lasttoggle_flag) lasttoggle = NULL;
 
   MCMCDyn_init_common(tails, heads, *time, lasttoggle, *n_edges,
 		      *n_nodes, *directed_flag, *bipartite, &nwp,

--- a/src/godfather.h
+++ b/src/godfather.h
@@ -15,7 +15,7 @@
 #include "MCMCDyn.h"
 
 /* Function prototypes */
-void godfather_wrapper(int *tails, int *heads, int *time, int *lasttoggle, int *n_edges,
+void godfather_wrapper(int *tails, int *heads, int *time, int *lasttoggle_flag, int *lasttoggle, int *n_edges,
 		       int *n_nodes, int *directed_flag, int *bip, 
 		       int *nterms, char **funnames, char **sonames, double *inputs,
 		       int *total_toggles, int *toggletimes, 

--- a/src/init.c
+++ b/src/init.c
@@ -19,14 +19,14 @@
 #include <R_ext/Rdynload.h>
 
 /* .C calls */
-extern void godfather_wrapper(void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *);
-extern void MCMCDyn_wrapper(void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *);
-extern void MCMCDynSArun_wrapper(void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *);
+extern void godfather_wrapper(void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *);
+extern void MCMCDyn_wrapper(void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *);
+extern void MCMCDynSArun_wrapper(void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *, void *);
 
 static const R_CMethodDef CEntries[] = {
-    {"godfather_wrapper",    (DL_FUNC) &godfather_wrapper,    24},
-    {"MCMCDyn_wrapper",      (DL_FUNC) &MCMCDyn_wrapper,      56},
-    {"MCMCDynSArun_wrapper", (DL_FUNC) &MCMCDynSArun_wrapper, 52},
+    {"godfather_wrapper",    (DL_FUNC) &godfather_wrapper,    25},
+    {"MCMCDyn_wrapper",      (DL_FUNC) &MCMCDyn_wrapper,      57},
+    {"MCMCDynSArun_wrapper", (DL_FUNC) &MCMCDynSArun_wrapper, 53},
     {NULL, NULL, 0}
 };
 


### PR DESCRIPTION
Both tergm (handled here) and ergm (handled in separate PR) master branches set the `lasttoggle` argument to various `C` functions equal to `as.integer(0)` when `Clist$lasttoggle` is `NULL` on the `R` side.  The `C` code then checks `*lasttoggle == 0` and interprets a `TRUE` as meaning that `lasttoggle` should be set to `NULL` in the `C` code (i.e. effectively ignored).  This is a logic error as the first entry in `lasttoggle` can quite legitimately be equal to zero even if `Clist$lasttoggle` was not `NULL` in the `R` code.  This caused a failure in the `sim_gf_sum` test in `tergm` where `lasttoggle` was ignored when it should not have been, producing incorrect statistics for durational terms.  This PR fixes the problem by adding a flag to `C` functions for whether `lasttoggle` should be ignored or not.