### PR TITLE
call summary on ergm_models rather than formulas

### DIFF
--- a/R/simulate.tergm.R
+++ b/R/simulate.tergm.R
@@ -361,8 +361,8 @@ simulate_formula.network <- function(object, nsim=1, seed=NULL,
                               proposal,
                               eta, control=control, verbose=verbose)
     
-    stats.gen <- if(control$collect) mcmc(sweep(z$statsmatrix.gen,2,summary(formula, basis=nw, dynamic=TRUE),"+"),start=time.burnin+1,thin=time.interval)
-    stats.mon <- if(!is.null(model.mon)) mcmc(sweep(z$statsmatrix.mon,2,summary(monitor, basis=nw, dynamic=TRUE),"+"),start=time.burnin+1,thin=time.interval)
+    stats.gen <- if(control$collect) mcmc(sweep(z$statsmatrix.gen,2,summary(model, nw=nw),"+"),start=time.burnin+1,thin=time.interval)
+    stats.mon <- if(!is.null(model.mon)) mcmc(sweep(z$statsmatrix.mon,2,summary(model.mon, nw=nw),"+"),start=time.burnin+1,thin=time.interval)
 
     out <-
       switch(output,


### PR DESCRIPTION
in tergm's simulate_formula.network

This should help efficiency when stats are required in repeated calls to `simulate` with large networks and short `MCMC` runs (where `ergm_model` time can be a bottleneck).

Should also correctly take `term.options` into account, which are passed when initializing the models but were not passed in the `summary` calls on formulas.

Passing `dynamic = TRUE` to `summary.ergm_model` doesn't do anything so I've dropped that argument from the summary calls.

I don't see a downside here but just in case...