### PR TITLE
speed up a check in tergm.godfather

### DIFF
--- a/R/tergm.godfather.R
+++ b/R/tergm.godfather.R
@@ -132,7 +132,13 @@ tergm.godfather <- function(formula, changes=NULL, toggles=changes[,-4,drop=FALS
     nw %n% "time" <- start
   }
 
-  if(!is.directed(nw)) toggles[,2:3] <- t(apply(toggles[,2:3,drop=FALSE], 1, sort))
+  if(!is.directed(nw)) {
+    tails <- toggles[,2]
+    heads <- toggles[,3]
+    toggles[,2] <- pmin(tails, heads)
+    toggles[,3] <- pmax(tails, heads)
+  }
+  
   toggles <- toggles[order(toggles[,1],toggles[,2],toggles[,3]),,drop=FALSE]
 
   formula <- nonsimp_update.formula(formula, nw~., from.new="nw")


### PR DESCRIPTION
The `t(apply(...))` line can be quite slow, with `pmin/pmax` being substantially faster.

e.g.

```
require(tergm)
nw <- network.initialize(1000, dir = F)
logit <- function(p) log(p/(1-p))
D <- 10
density <- 1/500
s <- simulate(nw ~ Form(~edges) + Persist(~edges),
              coef = c(logit(density) - log(D), log(D - 1)),
              output = "changes",
              time.slices = 1000,
              dynamic = TRUE)
              
st <- Sys.time()
tgf <- tergm.godfather(nw ~ edges,
                       toggles = s[,-4L])
et <- Sys.time()
print(et - st)
```

gives

```
Time difference of 6.745225 secs
```

with `master`, and

```
Time difference of 0.231977 secs
```

with the update in this PR.