### PR TITLE
correct strat mixing type toggleability check in discordBDStratTNT

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,4 +56,4 @@ Remotes: github::statnet/statnet.common@master,
     github::statnet/network@master,
     github::statnet/networkDynamic@master,
     github::statnet/ergm@ergm_block,
-    github::statnet/ergm.multi@master
+    github::statnet/ergm.multi@ergm_block

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,5 +55,5 @@ Encoding: UTF-8
 Remotes: github::statnet/statnet.common@master,
     github::statnet/network@master,
     github::statnet/networkDynamic@master,
-    github::statnet/ergm@ergm_block,
-    github::statnet/ergm.multi@ergm_block
+    github::statnet/ergm@master,
+    github::statnet/ergm.multi@master

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,5 +55,5 @@ Encoding: UTF-8
 Remotes: github::statnet/statnet.common@master,
     github::statnet/network@master,
     github::statnet/networkDynamic@master,
-    github::statnet/ergm@master,
+    github::statnet/ergm@ergm_block,
     github::statnet/ergm.multi@master

--- a/tests/testthat/helper-CMLE.R
+++ b/tests/testthat/helper-CMLE.R
@@ -14,6 +14,7 @@ options(tergm.eval.loglik = FALSE, useFancyQuotes = FALSE)
 
 CMLE.tools <- new.env()
 
+CMLE.tools$tolerance <- 4
 CMLE.tools$n <- 10
 CMLE.tools$m <- 6
 CMLE.tools$theta <- -1.5

--- a/tests/testthat/test-discord-proposals.R
+++ b/tests/testthat/test-discord-proposals.R
@@ -502,8 +502,7 @@ test_that("discordBDStratTNT handles undirected heterogeneous degree bound satur
                                  + strat(attr = ~strat_attr, pmat = pmat),
                   output = "final",
                   time.slices = 3,
-                  dynamic = TRUE,
-                  control = list(MCMC.burnin.min = 1e4, MCMC.burnin.max = 1e5))
+                  dynamic = TRUE)
   ## check constraints
   expect_true(all(summary(nws ~ nodemix(~blocks_attr, levels2 = levels2)) == 0))
   el <- as.edgelist(nws)
@@ -519,8 +518,7 @@ test_that("discordBDStratTNT handles undirected heterogeneous degree bound satur
                                   + strat(attr = ~strat_attr, pmat = pmat),
                    output = "final",
                    time.slices = 3,
-                   dynamic = TRUE,
-                   control = list(MCMC.burnin.min = 1e4, MCMC.burnin.max = 1e5))
+                   dynamic = TRUE)
   ## check constraints
   expect_true(all(summary(nws2 ~ nodemix(~blocks_attr, levels2 = levels2)) == 0))
   el <- as.edgelist(nws2)
@@ -553,8 +551,7 @@ test_that("discordBDStratTNT handles directed heterogeneous degree bound saturat
                                  + strat(attr = ~strat_attr, pmat = pmat),
                   output = "final",
                   time.slices = 3,
-                  dynamic = TRUE,
-                  control = list(MCMC.burnin.min = 1e3, MCMC.burnin.max = 1e5))
+                  dynamic = TRUE)
   ## check constraints
   expect_true(all(summary(nws ~ nodemix(~blocks_attr, levels2 = levels2)) == 0))
   el <- as.edgelist(nws)
@@ -573,8 +570,7 @@ test_that("discordBDStratTNT handles directed heterogeneous degree bound saturat
                                   + strat(attr = ~strat_attr, pmat = pmat),
                    output = "final",
                    time.slices = 3,
-                   dynamic = TRUE,
-                   control = list(MCMC.burnin.min = 1e3, MCMC.burnin.max = 1e5))
+                   dynamic = TRUE)
   ## check constraints
   expect_true(all(summary(nws2 ~ nodemix(~blocks_attr, levels2 = levels2)) == 0))
   el <- as.edgelist(nws2)
@@ -610,8 +606,7 @@ test_that("discordBDStratTNT handles bipartite heterogeneous degree bound satura
                                  + strat(attr = ~strat_attr, pmat = pmat),
                   output = "final",
                   time.slices = 3,
-                  dynamic = TRUE,
-                  control = list(MCMC.burnin.min = 1e4, MCMC.burnin.max = 1e5))
+                  dynamic = TRUE)
   ## check constraints
   expect_true(all(summary(nws ~ nodemix(~blocks_attr, levels2 = levels2)) == 0))
   el <- as.edgelist(nws)
@@ -627,8 +622,7 @@ test_that("discordBDStratTNT handles bipartite heterogeneous degree bound satura
                                   + strat(attr = ~strat_attr, pmat = pmat),
                    output = "final",
                    time.slices = 3,
-                   dynamic = TRUE,
-                   control = list(MCMC.burnin.min = 1e4, MCMC.burnin.max = 1e5))
+                   dynamic = TRUE)
   ## check constraints
   expect_true(all(summary(nws2 ~ nodemix(~blocks_attr, levels2 = levels2)) == 0))
   el <- as.edgelist(nws2)
@@ -658,8 +652,7 @@ test_that("discordBDStratTNT handles undirected homogeneous degree bound saturat
                                  + strat(attr = ~strat_attr, pmat = pmat),
                   output = "final",
                   time.slices = 3,
-                  dynamic = TRUE,
-                  control = list(MCMC.burnin.min = 1e4, MCMC.burnin.max = 1e5))
+                  dynamic = TRUE)
   ## check constraints
   expect_true(all(summary(nws ~ nodemix(~blocks_attr, levels2 = levels2)) == 0))
   el <- as.edgelist(nws)
@@ -674,8 +667,7 @@ test_that("discordBDStratTNT handles undirected homogeneous degree bound saturat
                                   + strat(attr = ~strat_attr, pmat = pmat),
                    output = "final",
                    time.slices = 3,
-                   dynamic = TRUE,
-                   control = list(MCMC.burnin.min = 1e4, MCMC.burnin.max = 1e5))
+                   dynamic = TRUE)
   ## check constraints
   expect_true(all(summary(nws2 ~ nodemix(~blocks_attr, levels2 = levels2)) == 0))
   el <- as.edgelist(nws2)
@@ -704,8 +696,7 @@ test_that("discordBDStratTNT handles directed homogeneous degree bound saturatio
                                  + strat(attr = ~strat_attr, pmat = pmat),
                   output = "final",
                   time.slices = 3,
-                  dynamic = TRUE,
-                  control = list(MCMC.burnin.min = 1e4, MCMC.burnin.max = 1e5))
+                  dynamic = TRUE)
   ## check constraints
   expect_true(all(summary(nws ~ nodemix(~blocks_attr, levels2 = levels2)) == 0))
   el <- as.edgelist(nws)
@@ -722,8 +713,7 @@ test_that("discordBDStratTNT handles directed homogeneous degree bound saturatio
                                   + strat(attr = ~strat_attr, pmat = pmat),
                    output = "final",
                    time.slices = 3,
-                   dynamic = TRUE,
-                   control = list(MCMC.burnin.min = 1e4, MCMC.burnin.max = 1e5))
+                   dynamic = TRUE)
   ## check constraints
   expect_true(all(summary(nws2 ~ nodemix(~blocks_attr, levels2 = levels2)) == 0))
   el <- as.edgelist(nws2)
@@ -754,8 +744,7 @@ test_that("discordBDStratTNT handles bipartite homogeneous degree bound saturati
                                  + strat(attr = ~strat_attr, pmat = pmat),
                   output = "final",
                   time.slices = 3,
-                  dynamic = TRUE,
-                  control = list(MCMC.burnin.min = 1e4, MCMC.burnin.max = 1e5))
+                  dynamic = TRUE)
   ## check constraints
   expect_true(all(summary(nws ~ nodemix(~blocks_attr, levels2 = levels2)) == 0))
   el <- as.edgelist(nws)
@@ -770,8 +759,7 @@ test_that("discordBDStratTNT handles bipartite homogeneous degree bound saturati
                                   + strat(attr = ~strat_attr, pmat = pmat),
                    output = "final",
                    time.slices = 3,
-                   dynamic = TRUE,
-                   control = list(MCMC.burnin.min = 1e4, MCMC.burnin.max = 1e5))
+                   dynamic = TRUE)
   ## check constraints
   expect_true(all(summary(nws2 ~ nodemix(~blocks_attr, levels2 = levels2)) == 0))
   el <- as.edgelist(nws2)

--- a/tests/testthat/test-discord-proposals.R
+++ b/tests/testthat/test-discord-proposals.R
@@ -778,3 +778,69 @@ test_that("discordBDStratTNT handles bipartite homogeneous degree bound saturati
   degs <- tabulate(c(el), nbins = net_size)
   expect_true(all(degs <= maxout))
 })
+
+test_that("free dyads vary under discordBDStratTNT", {
+  net_size <- 9
+  bip_size <- 5
+  nsim <- 200
+
+  blocks_levels_2 <- matrix(FALSE, nrow = 3, ncol = 3)
+  blocks_levels_2[1,1] <- TRUE
+  blocks_levels_2[2,3] <- TRUE
+
+  net_attrs_list <- list(list(n = net_size, directed = FALSE, bipartite = FALSE),
+                         list(n = net_size, directed = TRUE, bipartite = FALSE),
+                         list(n = net_size, directed = FALSE, bipartite = bip_size))
+
+  for (i in seq_along(net_attrs_list)) {
+    nw <- do.call(network.initialize, net_attrs_list[[i]])
+
+    dyad_mat <- !diag(net_size)
+    if (is.bipartite(nw)) {
+      dyad_mat[-seq_len(bip_size),] <- FALSE
+      dyad_mat[,seq_len(bip_size)] <- FALSE
+    } else if (!is.directed(nw)) {
+      dyad_mat[lower.tri(dyad_mat)] <- FALSE
+    }
+
+    ## check dyad count
+    expect_equal(sum(dyad_mat), network.dyadcount(nw))
+
+    ## construct logical vector of free dyads in the network
+    free_dyads <- !diag(net_size)
+    free_dyads[seq_len(net_size) %% 3 == 1, seq_len(net_size) %% 3 == 1] <- FALSE
+    free_dyads[seq_len(net_size) %% 3 == 2, seq_len(net_size) %% 3 == 0] <- FALSE
+    if (!is.directed(nw) && !is.bipartite(nw)) {
+      free_dyads <- free_dyads & t(free_dyads)
+    }
+    free_dyads <- free_dyads[which(dyad_mat)]
+
+    ## restrict size of dyad_mat in bipartite case
+    if (is.bipartite(nw)) {
+      dyad_mat <- dyad_mat[seq_len(bip_size), -seq_len(bip_size)]
+    }
+
+    ## perform simulation
+    stats <- simulate(nw ~ edges,
+                      coef = c(0),
+                      monitor = ~nodemix(~seq_len(net_size), levels2 = dyad_mat),
+                      time.slices = 2*nsim,
+                      constraints = "discordBDStratTNT"~strat(~rep(1:2, length.out = net_size), pmat = matrix(4 + runif(4), ncol = 2))
+                                    + blocks(~rep(1:3, length.out = net_size), levels2 = blocks_levels_2)
+                                    + bd(maxout = 3),
+                      output = "stats",
+                      dynamic = TRUE,
+                      control = list(MCMC.burnin.min = 1e3, MCMC.burnin.max = 1e3))
+
+    ## drop first half as burn-in
+    stats <- stats[-seq_len(nsim),]
+
+    ## check number of stats
+    expect_equal(NCOL(stats), network.dyadcount(nw))
+
+    ## confirm that free dyads take two states and fixed dyads take one state
+    for (i in seq_len(NCOL(stats))) {
+      expect_true(length(unique(stats[, i])) == 1 + free_dyads[i])
+    }
+  }
+})


### PR DESCRIPTION
This PR corrects discordBDStratTNT to consider all free edges when checking strat mixing type toggleability.  Formerly only non-discordant edges were considered, which in rare cases could lead to incorrect behavior.

A related test has been added, and the run lengths of some other tests have been reduced to keep total test runtime from increasing.

The new test requires the updates in `ergm@ergm_block`.  There are no updates to `ergm.multi`, but the `ergm.multi@ergm_block` branch has been created to provide a version of `ergm.multi` with `ergm@ergm_block` in its remotes field (so that `pak` can solve the dependencies).

Once `ergm@ergm_block` is merged into `ergm@master` (see statnet/ergm#539), the `ergm@ergm_block` and `ergm.multi@ergm_block` remotes in this PR can be reverted to `ergm@master` and `ergm.multi@master`, and the `ergm_block` branches of `ergm` and `ergm.multi` can be deleted.

There was an unrelated CMLE test failure (also present in `tergm@master`), and I've increased the CMLE test tolerance in this branch to avoid that failure.
